### PR TITLE
Fix python requirements, bug in client code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Prereqs:
     - gpytorch current
     - Pyro current
     - matplotlib current
-    - express
-    - python-socketio
+    - python-socketio 4.x
+    - eventlet
+    - scipy
+    - requests
 - UI and Communication Server
   - node.js 10+ (Tested on 10 and 12)
   - yarn v1 (untested on yarn 2)

--- a/client/node-ui/src/renderer/main.js
+++ b/client/node-ui/src/renderer/main.js
@@ -13,7 +13,7 @@ import path from 'path';
 const userFolder =
   process.env.APPDATA ||
   (process.platform === 'darwin'
-    ? process.env.HOME + 'Library/Preferences'
+    ? process.env.HOME + '/Library/Preferences'
     : process.env.HOME + '/.local/share');
 
 // duplicating stuff for full app access

--- a/client/node-ui/src/renderer/store/backend/substance.js
+++ b/client/node-ui/src/renderer/store/backend/substance.js
@@ -12,7 +12,7 @@ let tkDir = 'C:/Program Files/Allegorithmic/Substance Automation Toolkit';
 const userFolder =
   process.env.APPDATA ||
   (process.platform === 'darwin'
-    ? process.env.HOME + 'Library/Preferences'
+    ? process.env.HOME + '/Library/Preferences'
     : process.env.HOME + '/.local/share');
 const renderDir = path.join(userFolder, 'parameter-toolbox', 'sbsRender');
 

--- a/client/node-ui/src/renderer/store/index.js
+++ b/client/node-ui/src/renderer/store/index.js
@@ -13,7 +13,7 @@ Vue.use(Vuex);
 const userFolder =
   process.env.APPDATA ||
   (process.platform === 'darwin'
-    ? process.env.HOME + 'Library/Preferences'
+    ? process.env.HOME + '/Library/Preferences'
     : process.env.HOME + '/.local/share');
 
 fs.ensureDirSync(path.join(userFolder, 'parameter-toolbox', 'logs'));


### PR DESCRIPTION
This PR adds more python requirements to the README—after installing the stated requirements, I was still missing `eventlet`, `scipy`, and `requests` when running `python dsServer.py`. Also, I specified that `python-socketio` should be version 4.x in order to be compatible with your JS Socket.IO version (2.x); see [this thread](https://github.com/miguelgrinberg/python-socketio/issues/586) for more details. Also, I deleted `express`, as that is not a python requirement (correct me if I'm wrong)

Also, in the client renderer, I fixed a minor bug (for Mac users) where a path is missing a slash, causing the electron app to error.